### PR TITLE
Bug/deactivate payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ the set _Activate On Status_ config option
 - Stricter initial validation of the API Key
 
 ## [1.4.2] - 2019-06-28
-- Stand suffixes applied to tables
-- Take into account constent from merchant when removing data on uninstall
-- Add plugin description and change log
-- Format and lint PHP code
+- Standard suffixes applied to tables
+- Takes into account consent from merchant when removing data on uninstall
+- Adds plugin description and change log
+- Formats and lints PHP code

--- a/FinancePlugin.php
+++ b/FinancePlugin.php
@@ -38,17 +38,6 @@ class FinancePlugin extends Plugin
          * @var \Shopware\Components\Plugin\PaymentInstaller $installer Installer
          */
         $installer = $this->container->get('shopware.plugin_payment_installer');
-        $options = [
-            'name' => 'finance_plugin',
-            'description' => 'Pay By Finance',
-            'action' => 'FinancePlugin',
-            'active' => 1,
-            'position' => 0,
-            'additionalDescription' =>
-                '<div id="payment_desc">'
-                . 'Finance your cart'
-                . '</div>'
-        ];
 
         $service = $this->container->get('shopware_attribute.crud_service');
         $service->update(
@@ -98,6 +87,17 @@ class FinancePlugin extends Plugin
             ]
         );
 
+        $options = [
+            'name' => 'finance_plugin',
+            'description' => 'Pay By Finance',
+            'action' => 'FinancePlugin',
+            'active' => 1,
+            'position' => 0,
+            'additionalDescription' =>
+                '<div id="payment_desc">'
+                . 'Finance your cart'
+                . '</div>'
+        ];
         $installer->createOrUpdate($context->getPlugin(), $options);
     }
 
@@ -145,6 +145,12 @@ class FinancePlugin extends Plugin
     {
         $this->_setActiveFlag($context->getPlugin()->getPayments(), false);
         $context->scheduleClearCache(ActivateContext::CACHE_LIST_ALL);
+        $installer = $this->container->get('shopware.plugin_payment_installer');
+        $options = [
+            'name' => 'finance_plugin',
+            'active' => 0
+        ];
+        $installer->createOrUpdate($context->getPlugin(), $options);
     }
 
     /**

--- a/FinancePlugin.php
+++ b/FinancePlugin.php
@@ -111,6 +111,12 @@ class FinancePlugin extends Plugin
     public function uninstall(UninstallContext $context)
     {
         $this->_setActiveFlag($context->getPlugin()->getPayments(), false);
+        $installer = $this->container->get('shopware.plugin_payment_installer');
+        $options = [
+            'name' => 'finance_plugin',
+            'active' => 0
+        ];
+        $installer->createOrUpdate($context->getPlugin(), $options);
 
         if(!$context->keepUserData()){
             $service = $this->container->get('shopware_attribute.crud_service');

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,10 +22,10 @@
         <changes>
             <![CDATA[
             <ul>
-            <li>Stand suffixes applied to tables</li>
-            <li>Take into account constent from merchant when removing data on uninstall</li>
-            <li>Add plugin description and change log</li>
-            <li>Format and lint PHP code</li>
+            <li>Standard suffixes applied to tables</li>
+            <li>Takes into account consent from merchant when removing data on uninstall</li>
+            <li>Adds plugin description and change log</li>
+            <li>Formats and lints PHP code</li>
             </ul>
             ]]>
         </changes>


### PR DESCRIPTION
Deactivates the related payment method so that it no longer appears on the checkout page after the plugin is deactivated (causing an error). Can't completely remove it because any orders that exist on the backend with the provider would apparently go skewiff